### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -6,9 +6,8 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 
 Issue 542 Deploy Workflow fails
 
-### Codesigning from Azure Key Vaults
-
-With this set up in your Al-GO project you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module. For more information see: [Code Signing in Al-Go](https://github.com/microsoft/AL-Go/blob/main/Scenarios/CodesigningInAlGo.md)
+### New Settings
+- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
 
 ## v3.1
 

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -79,13 +79,6 @@ jobs:
           }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
 
-      - name: test
-        id: test
-        env:
-          keyVaultName: ${{ fromJSON(secrets.AZURE_CREDENTIALS).keyVaultName || fromJSON(env.Settings).KeyVaultName }}
-        run: |
-          Write-Host "keyVaultName: $env:keyVaultName"
-
       - name: Read secrets
         uses: aholstrup1/AL-Go-Actions/ReadSecrets@main
         env:
@@ -259,11 +252,8 @@ jobs:
         uses: aholstrup1/AL-Go-Actions/Sign@main
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          azureKeyVaultName: ${{ fromJSON(secrets.AZURE_CREDENTIALS).keyVaultName }}
-          azureKeyVaultClientID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }}
-          azureKeyVaultClientSecret: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientSecret }}
-          azureKeyVaultTenantID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).tenantId }}
-          azureKeyVaultCertificateName: ${{ env.keyVaultCodesignCertificateName }}
+          azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+          settingsJson: ${{ env.Settings }}
           pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
@@ -453,11 +443,8 @@ jobs:
         uses: aholstrup1/AL-Go-Actions/Sign@main
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          azureKeyVaultName: ${{ fromJSON(secrets.AZURE_CREDENTALS).keyVaultName }}
-          azureKeyVaultClientID: ${{ fromJSON(secrets.AZURE_CREDENTALS).clientId }}
-          azureKeyVaultClientSecret: ${{ fromJSON(secrets.AZURE_CREDENTALS).clientSecret }}
-          azureKeyVaultTenantID: ${{ fromJSON(secrets.AZURE_CREDENTALS).tenantId }}
-          azureKeyVaultCertificateName: ${{ env.keyVaultCodesignCertificateName }}
+          azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+          settingsJson: ${{ env.Settings }}
           pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues

Issue 542 Deploy Workflow fails

### New Settings
- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
